### PR TITLE
Added links to employer footer

### DIFF
--- a/src/SFA.DAS.EmployerDemand.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.EmployerDemand.Web/Views/Shared/_Layout.cshtml
@@ -157,31 +157,31 @@
                 <ul class="govuk-footer__inline-list">
 
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="#" target="_blank" rel="noreferrer noopener">
+                        <a class="govuk-footer__link" href="https://help.apprenticeships.education.gov.uk/hc/en-gb" target="_blank" rel="noreferrer noopener">
                             Help
                         </a>
                     </li>
 
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="#" target="_blank" rel="noreferrer noopener">
+                        <a class="govuk-footer__link" href="https://www.smartsurvey.co.uk/s/1ZRQ3HFAT/" target="_blank" rel="noreferrer noopener">
                             Feedback
                         </a>
                     </li>
 
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="#">
+                        <a class="govuk-footer__link" href="https://findapprenticeshiptraining.apprenticeships.education.gov.uk/privacy">
                             Privacy
                         </a>
                     </li>
 
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="#">
+                        <a class="govuk-footer__link" href="https://findapprenticeshiptraining.apprenticeships.education.gov.uk/accessibility">
                             Accessibility statement
                         </a>
                     </li>
 
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="#">
+                        <a class="govuk-footer__link" href="https://findapprenticeshiptraining.apprenticeships.education.gov.uk/cookies">
                             Cookies
                         </a>
                     </li>


### PR DESCRIPTION
Header and footer were already present, only footer links needed adding.
One note: the cookies link points to the FAT cookies page which follows through to the FAT cookies details page. I've let Gerard know that an AED specific details page will need creating at some point, but for now it's just pointing at FAT